### PR TITLE
Update sh-ep-scrapy version (1.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-
 attrs==15.2.0             # via service-identity
 boto==2.42.0
 cffi==1.6.0               # via cryptography
@@ -13,7 +12,7 @@ cssselect==0.9.1          # via premailer, scrapy
 cssutils==1.0.1           # via premailer
 enum34==1.1.4             # via cryptography
 functools32==3.2.3.post2  # via jsonschema
-hubstorage==0.22.0        # via scrapinghub-entrypoint-scrapy, scrapy-pagestorage
+hubstorage==0.23.5        # via scrapinghub-entrypoint-scrapy, scrapy-pagestorage
 idna==2.1                 # via cryptography
 ipaddress==1.0.16         # via cryptography
 Jinja2==2.8
@@ -35,7 +34,7 @@ requests==2.10.0          # via hubstorage, monkeylearn, slackclient
 retrying==1.3.3           # via hubstorage
 s3cmd==1.6.1              # via scrapy-dotpersistence
 schematics==1.0.4
-scrapinghub-entrypoint-scrapy==0.8.8
+scrapinghub-entrypoint-scrapy==0.8.10
 scrapy-crawlera==1.1.0
 scrapy-dotpersistence==0.2.2
 scrapy-pagestorage==0.1.0
@@ -53,4 +52,4 @@ zope.interface==4.1.3     # via twisted
 
 # The following packages are commented out because they are
 # considered to be unsafe in a requirements file:
-# setuptools                # via cryptography, zope.interface
+# setuptools                # via cryptography


### PR DESCRIPTION
Updating to provide the following fixes to the stack:
- https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/pull/31
- https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/pull/30
- https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/pull/29
- https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/pull/27

Review, please.