### PR TITLE
Update SH python bindings (1.1-py3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ONBUILD RUN test -n $APT_PROXY && echo 'Acquire::http::Proxy \"$APT_PROXY\";' \
 # TERM needs to be set here for exec environments
 # PIP_TIMEOUT so installation doesn't hang forever
 ENV TERM=xterm \
-    PIP_TIMEOUT=180
+    PIP_TIMEOUT=180 \
+    SHUB_ENFORCE_PIP_CHECK=1
 
 RUN apt-get update -qq && \
     apt-get install -qy \

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@
 #   pip-compile --output-file requirements.txt requirements.in
 #
 
-Scrapy==1.1.1
+Scrapy==1.1.3
 
 # scrapinghub glue
 scrapinghub-entrypoint-scrapy
@@ -23,6 +23,7 @@ Jinja2
 jsonschema
 premailer==2.9.2
 schematics==1.0.4
+scrapinghub==1.9.0
 slackclient
 python-slugify
 # required by Images addon

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,13 +14,13 @@ cryptography==1.4         # via pyopenssl
 cssselect==0.9.2          # via parsel, premailer, scrapy
 cssutils==1.0.1           # via premailer
 docutils==0.12            # via awscli, botocore
-hubstorage==0.23.5        # via scrapinghub-entrypoint-scrapy, scrapy-pagestorage
+hubstorage==0.23.6        # via scrapinghub-entrypoint-scrapy, scrapy-pagestorage
 idna==2.1                 # via cryptography
-Jinja2==2.8
+jinja2==2.8
 jmespath==0.9.0           # via botocore
 jsonschema==2.5.1
 lxml==3.6.1               # via parsel, premailer, scrapy
-MarkupSafe==0.23          # via jinja2
+markupsafe==0.23          # via jinja2
 mock==1.0.1               # via schematics
 monkeylearn==0.3.5
 parsel==1.0.2             # via scrapy
@@ -28,32 +28,32 @@ premailer==2.9.2
 pyasn1-modules==0.0.8     # via service-identity
 pyasn1==0.1.9             # via cryptography, pyasn1-modules, rsa, service-identity
 pycparser==2.14           # via cffi
-PyDispatcher==2.0.5       # via scrapy
+pydispatcher==2.0.5       # via scrapy
 pyopenssl==16.0.0         # via scrapy, service-identity
 python-dateutil==2.5.3    # via botocore
 python-slugify==1.2.1
 queuelib==1.4.2           # via scrapy
-requests==2.10.0          # via hubstorage, monkeylearn, slackclient
-retrying==1.3.3           # via hubstorage
+requests==2.10.0          # via hubstorage, monkeylearn, scrapinghub, slackclient
+retrying==1.3.3           # via hubstorage, scrapinghub
 rsa==3.4.2                # via awscli
 s3transfer==0.1.1         # via awscli
 schematics==1.0.4
 scrapinghub-entrypoint-scrapy==0.8.10
+scrapinghub==1.9.0
 scrapy-crawlera==1.1.0
 scrapy-dotpersistence==0.3.0
 scrapy-pagestorage==0.1.0
 scrapy-splash==0.7
-Scrapy==1.1.1             # via scrapinghub-entrypoint-scrapy, scrapy-dotpersistence, scrapy-pagestorage, scrapylib
+scrapy==1.1.3
 scrapylib==1.7.0
 service-identity==16.0.0  # via scrapy
 six==1.10.0
 slackclient==1.0.1
-Twisted==16.3.0           # via scrapy
-Unidecode==0.4.19         # via python-slugify
+twisted==16.3.0           # via scrapy
+unidecode==0.4.19         # via python-slugify
 w3lib==1.14.3             # via parsel, scrapy
 websocket-client==0.37.0  # via slackclient
 zope.interface==4.2.0     # via twisted
 
-# The following packages are commented out because they are
-# considered to be unsafe in a requirements file:
+# The following packages are considered to be unsafe in a requirements file:
 # setuptools                # via cryptography, zope.interface

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cryptography==1.4         # via pyopenssl
 cssselect==0.9.2          # via parsel, premailer, scrapy
 cssutils==1.0.1           # via premailer
 docutils==0.12            # via awscli, botocore
-hubstorage==0.23.6        # via scrapinghub-entrypoint-scrapy, scrapy-pagestorage
+hubstorage==0.23.6        # via scrapy-pagestorage
 idna==2.1                 # via cryptography
 jinja2==2.8
 jmespath==0.9.0           # via botocore
@@ -38,7 +38,7 @@ retrying==1.3.3           # via hubstorage, scrapinghub
 rsa==3.4.2                # via awscli
 s3transfer==0.1.1         # via awscli
 schematics==1.0.4
-scrapinghub-entrypoint-scrapy==0.8.10
+scrapinghub-entrypoint-scrapy==0.8.11
 scrapinghub==1.9.0
 scrapy-crawlera==1.1.0
 scrapy-dotpersistence==0.3.0


### PR DESCRIPTION
- adding `python-scrapinghub==1.9.0`
- updating `python-hubstorage==0.23.6`
- updating `Scrapy==1.1.3`
- enforce pip-check on deploy

All other changes were triggered by pip-compile, it enforces lower-case mode now.

Review, please.