### PR TITLE
Fix DeltaFetch addon (1.2)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,7 @@ scrapinghub-entrypoint-scrapy
 scrapylib
 scrapy-splash
 scrapy-crawlera
+scrapy-deltafetch
 scrapy-dotpersistence
 scrapy-pagestorage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,10 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+appdirs==1.4.0            # via setuptools
 attrs==15.2.0             # via service-identity
 boto==2.41.0
+bsddb3==6.2.4             # via scrapy-deltafetch
 cffi==1.6.0               # via cryptography
 cryptography==1.3.2       # via pyopenssl
 cssselect==0.9.1          # via parsel, premailer, scrapy
@@ -21,6 +23,7 @@ lxml==3.6.0               # via parsel, premailer, scrapy
 markupsafe==0.23          # via jinja2
 mock==1.0.1               # via schematics
 monkeylearn==0.3.5
+packaging==16.8           # via setuptools
 parsel==1.0.2             # via scrapy
 premailer==2.9.2
 pyasn1-modules==0.0.8     # via service-identity
@@ -28,6 +31,7 @@ pyasn1==0.1.9             # via cryptography, pyasn1-modules, service-identity
 pycparser==2.14           # via cffi
 pydispatcher==2.0.5       # via scrapy
 pyopenssl==16.0.0         # via scrapy, service-identity
+pyparsing==2.1.10         # via packaging
 python-dateutil==2.5.3    # via s3cmd
 python-magic==0.4.11      # via s3cmd
 python-slugify==1.2.1
@@ -39,6 +43,7 @@ schematics==1.0.4
 scrapinghub-entrypoint-scrapy==0.8.11
 scrapinghub==1.9.0
 scrapy-crawlera==1.1.0
+scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.2.2
 scrapy-pagestorage==0.1.0
 scrapy-splash==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ requests==2.10.0          # via hubstorage, monkeylearn, scrapinghub, slackclien
 retrying==1.3.3           # via hubstorage, scrapinghub
 s3cmd==1.6.1              # via scrapy-dotpersistence
 schematics==1.0.4
-scrapinghub-entrypoint-scrapy==0.8.11
+scrapinghub-entrypoint-scrapy==0.8.12
 scrapinghub==1.9.0
 scrapy-crawlera==1.1.0
 scrapy-deltafetch==1.2.1


### PR DESCRIPTION
The PR contains the following things:

- add scrapy-deltafetch
- upgrade sh-ep-scrapy version to update outdated path to deltafetch