### PR TITLE
Fix DeltaFetch addon (1.3-py3)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,6 +12,7 @@ scrapinghub-entrypoint-scrapy
 scrapylib
 scrapy-splash
 scrapy-crawlera
+scrapy-deltafetch
 scrapy-dotpersistence
 scrapy-pagestorage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ retrying==1.3.3           # via scrapinghub
 rsa==3.4.2                # via awscli
 s3transfer==0.1.10        # via awscli
 schematics==1.0.4
-scrapinghub-entrypoint-scrapy==0.8.11
+scrapinghub-entrypoint-scrapy==0.8.12
 scrapinghub==1.9.0
 scrapy-crawlera==1.2.2
 scrapy-deltafetch==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ attrs==16.3.0             # via service-identity
 awscli==1.11.45           # via scrapy-dotpersistence
 boto==2.45.0
 botocore==1.5.8           # via awscli, s3transfer
+bsddb3==6.2.4             # via scrapy-deltafetch
 cffi==1.9.1               # via cryptography
 colorama==0.3.7           # via awscli
 constantly==15.1.0        # via twisted
@@ -18,11 +19,11 @@ cssutils==1.0.1           # via premailer
 docutils==0.13.1          # via awscli, botocore
 idna==2.2                 # via cryptography
 incremental==16.10.1      # via twisted
-Jinja2==2.9.5
+jinja2==2.9.5
 jmespath==0.9.1           # via botocore
 jsonschema==2.6.0
 lxml==3.7.2               # via parsel, premailer, scrapy
-MarkupSafe==0.23          # via jinja2
+markupsafe==0.23          # via jinja2
 mock==1.0.1               # via schematics
 monkeylearn==0.3.6
 packaging==16.8           # via setuptools
@@ -31,12 +32,12 @@ premailer==2.9.2
 pyasn1-modules==0.0.8     # via service-identity
 pyasn1==0.2.2             # via cryptography, pyasn1-modules, rsa, service-identity
 pycparser==2.17           # via cffi
-PyDispatcher==2.0.5       # via scrapy
-pyOpenSSL==16.2.0         # via scrapy, service-identity
+pydispatcher==2.0.5       # via scrapy
+pyopenssl==16.2.0         # via scrapy, service-identity
 pyparsing==2.1.10         # via packaging
 python-dateutil==2.6.0    # via botocore
 python-slugify==1.2.1
-PyYAML==3.12              # via awscli
+pyyaml==3.12              # via awscli
 queuelib==1.4.2           # via scrapy
 requests==2.13.0          # via monkeylearn, scrapinghub, slackclient
 retrying==1.3.3           # via scrapinghub
@@ -46,16 +47,17 @@ schematics==1.0.4
 scrapinghub-entrypoint-scrapy==0.8.11
 scrapinghub==1.9.0
 scrapy-crawlera==1.2.2
+scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.3.0
 scrapy-pagestorage==0.2.0
 scrapy-splash==0.7.1
-Scrapy==1.3.1             # via scrapinghub-entrypoint-scrapy, scrapy-dotpersistence, scrapy-pagestorage, scrapylib
+scrapy==1.3.1
 scrapylib==1.7.1
 service-identity==16.0.0  # via scrapy
 six==1.10.0
 slackclient==1.0.5
-Twisted==16.6.0           # via scrapy
-Unidecode==0.4.20         # via python-slugify
+twisted==16.6.0           # via scrapy
+unidecode==0.4.20         # via python-slugify
 w3lib==1.17.0             # via parsel, scrapy
 websocket-client==0.40.0  # via slackclient
 zope.interface==4.3.3     # via twisted


### PR DESCRIPTION
The PR contains the following things:

- add scrapy-deltafetch
- upgrade sh-ep-scrapy version to update outdated path to deltafetch