### PR TITLE
Upgrade Scrapy to 1.3.3 for scrapy:1.3 stack

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@
 #   pip-compile --output-file requirements.txt requirements.in
 #
 
-Scrapy==1.3.1
+Scrapy==1.3.3
 
 # scrapinghub glue
 scrapinghub-entrypoint-scrapy

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.3.0
 scrapy-pagestorage==0.2.0
 scrapy-splash==0.7.1
-scrapy==1.3.1
+scrapy==1.3.3
 scrapylib==1.7.1
 service-identity==16.0.0  # via scrapy
 six==1.10.0


### PR DESCRIPTION
The upgrade is related with recent update for Scrapy that contains a fix for list-spiders [issue](https://github.com/scrapy/scrapy/pull/2632) when import errors were swallowed.

Please, review.