### PR TITLE
Empty change to use a newer base image (1.1-py3)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ The repository includes a set of branches to maintain different stack versions d
 Versioning
 ==========
 
-We use git tags to pin a stack version and release a stack image to Docker hub.
+We use Git tags to pin a stack version and release a stack image to Docker hub.
 
 Versioning is done in the following manner:
 


### PR DESCRIPTION
I'm doing a separate commit to tag it differently (instead of rebuilding current version of the stack with Drone) to keep the previous version of stack unchanged, just in a case if we need to rollback.