### PR TITLE
Upgrade Pillow to 5.2.0 on scrapy 1.5-py3 stack

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -29,7 +29,7 @@ slackclient
 python-slugify
 # required by Images addon
 boto
-pillow
+pillow>=5.1.0
 
 # Requirements due to known bugs in dependencies
 Twisted >= 17.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ markupsafe==1.0           # via jinja2
 mock==1.0.1               # via schematics
 monkeylearn==0.3.7
 parsel==1.3.1             # via scrapy
-pillow==5.0.0
+pillow==5.2.0
 premailer==2.9.2
 pyasn1-modules==0.2.1     # via service-identity
 pyasn1==0.4.2             # via pyasn1-modules, rsa, service-identity
@@ -62,6 +62,6 @@ slackclient==1.1.0
 twisted==17.9.0
 unidecode==1.0.22         # via python-slugify
 urllib3==1.22             # via requests
-w3lib==1.18.0             # via parsel, scrapy
+w3lib==1.18.0             # via parsel, scrapy, scrapy-crawlera
 websocket-client==0.46.0  # via slackclient
 zope.interface==4.4.3     # via twisted


### PR DESCRIPTION
Upgrade Pillow due to [a memory leak found in 5.0.0](https://github.com/python-pillow/Pillow/issues/2972). 