### PR TITLE
Prepare upgraded stack with Scrapy 1.5.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@
 #   pip-compile --output-file requirements.txt requirements.in
 #
 
-Scrapy==1.5.0
+Scrapy==1.5.1
 
 # scrapinghub glue
 scrapinghub-entrypoint-scrapy

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,67 +5,68 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 asn1crypto==0.24.0        # via cryptography
-attrs==17.4.0             # via automat, service-identity
-automat==0.6.0            # via twisted
-awscli==1.14.20           # via scrapy-dotpersistence
-boto==2.48.0
-botocore==1.8.24          # via awscli, s3transfer
-bsddb3==6.2.5             # via scrapy-deltafetch
-certifi==2017.11.5        # via requests
-cffi==1.11.2              # via cryptography
+attrs==18.2.0             # via automat, service-identity, twisted
+automat==0.7.0            # via twisted
+awscli==1.16.33           # via scrapy-dotpersistence
+boto==2.49.0
+botocore==1.12.23         # via awscli, s3transfer
+bsddb3==6.2.6             # via scrapy-deltafetch
+certifi==2018.10.15       # via requests
+cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
-colorama==0.3.7           # via awscli
+colorama==0.3.9           # via awscli
 constantly==15.1.0        # via twisted
-cryptography==2.1.4       # via pyopenssl
+cryptography==2.3.1       # via pyopenssl
 cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 docutils==0.14            # via awscli, botocore
 enum34==1.1.6             # via cryptography
-functools32==3.2.3.post2  # via jsonschema
+functools32==3.2.3.post2  # via jsonschema, parsel
 futures==3.2.0            # via s3transfer
-hyperlink==17.3.1         # via twisted
-idna==2.6                 # via cryptography, requests
+hyperlink==18.0.0         # via twisted
+idna==2.7                 # via cryptography, hyperlink, requests
 incremental==17.5.0       # via twisted
-ipaddress==1.0.19         # via cryptography
+ipaddress==1.0.22         # via cryptography
 jinja2==2.10
 jmespath==0.9.3           # via botocore
 jsonschema==2.6.0
-lxml==4.1.1               # via parsel, premailer, scrapy
+lxml==4.2.5               # via parsel, premailer, scrapy
 markupsafe==1.0           # via jinja2
 mock==1.0.1               # via schematics
-monkeylearn==0.3.7
-parsel==1.3.1             # via scrapy
-pillow==5.2.0
+monkeylearn==3.2.1
+parsel==1.5.0             # via scrapy
+pillow==5.3.0
 premailer==2.9.2
-pyasn1-modules==0.2.1     # via service-identity
-pyasn1==0.4.2             # via pyasn1-modules, rsa, service-identity
-pycparser==2.18           # via cffi
+pyasn1-modules==0.2.2     # via service-identity
+pyasn1==0.4.4             # via pyasn1-modules, rsa, service-identity
+pycparser==2.19           # via cffi
 pydispatcher==2.0.5       # via scrapy
-pyopenssl==17.5.0         # via scrapy, service-identity
-python-dateutil==2.6.1    # via botocore
-python-slugify==1.2.4
-pyyaml==3.12              # via awscli
-queuelib==1.4.2           # via scrapy
-requests==2.18.4          # via monkeylearn, scrapinghub, slackclient
+pyhamcrest==1.9.0         # via twisted
+pyopenssl==18.0.0         # via scrapy, service-identity
+python-dateutil==2.7.3    # via botocore
+python-slugify==1.2.6
+pyyaml==3.13              # via awscli
+queuelib==1.5.0           # via scrapy
+requests==2.19.1          # via monkeylearn, scrapinghub, slackclient
 retrying==1.3.3           # via scrapinghub
 rsa==3.4.2                # via awscli
-s3transfer==0.1.12        # via awscli
+s3transfer==0.1.13        # via awscli
 schematics==1.0.4
 scrapinghub-entrypoint-scrapy==0.11.1
 scrapinghub==2.0.3
-scrapy-crawlera==1.3.0
+scrapy-crawlera==1.4.0
 scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.3.0
 scrapy-pagestorage==0.2.2
 scrapy-splash==0.7.2
-scrapy==1.5.0
+scrapy==1.5.1
 scrapylib==1.7.1
 service-identity==17.0.0  # via scrapy
 six==1.11.0
-slackclient==1.1.0
-twisted==17.9.0           # via scrapy
+slackclient==1.3.0
+twisted==18.9.0           # via scrapy
 unidecode==1.0.22         # via python-slugify
-urllib3==1.22             # via requests
-w3lib==1.18.0             # via parsel, scrapy, scrapy-crawlera
-websocket-client==0.46.0  # via slackclient
-zope.interface==4.4.3     # via twisted
+urllib3==1.23             # via botocore, requests
+w3lib==1.19.0             # via parsel, scrapy, scrapy-crawlera
+websocket-client==0.53.0  # via slackclient
+zope.interface==4.5.0     # via twisted


### PR DESCRIPTION
My guess it should be fine to upgrade current dependencies along with Scrapy upgrade. However I have doubts about `Twisted 17.9 -> 18.9`. Any objections?