### PR TITLE
Prepare a stack for latest Scrapy 1.6(-py3)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@
 #   pip-compile --output-file requirements.txt requirements.in
 #
 
-Scrapy==1.5.2
+Scrapy==1.6.0
 
 # scrapinghub glue
 scrapinghub-entrypoint-scrapy
@@ -24,7 +24,7 @@ Jinja2
 jsonschema
 premailer==2.9.2
 schematics==1.0.4
-scrapinghub==2.0.3
+scrapinghub==2.1.0
 slackclient
 python-slugify
 # required by Images addon

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,62 +7,62 @@
 asn1crypto==0.24.0        # via cryptography
 attrs==18.2.0             # via automat, service-identity, twisted
 automat==0.7.0            # via twisted
-awscli==1.16.33           # via scrapy-dotpersistence
+awscli==1.16.101          # via scrapy-dotpersistence
 boto==2.49.0
-botocore==1.12.23         # via awscli, s3transfer
+botocore==1.12.91         # via awscli, s3transfer
 bsddb3==6.2.6             # via scrapy-deltafetch
-certifi==2018.10.15       # via requests
+certifi==2018.11.29       # via requests
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
 colorama==0.3.9           # via awscli
 constantly==15.1.0        # via twisted
-cryptography==2.3.1       # via pyopenssl
+cryptography==2.5         # via pyopenssl, service-identity
 cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 docutils==0.14            # via awscli, botocore
 hyperlink==18.0.0         # via twisted
-idna==2.7                 # via cryptography, hyperlink, requests
+idna==2.8                 # via hyperlink, requests
 incremental==17.5.0       # via twisted
 jinja2==2.10
 jmespath==0.9.3           # via botocore
 jsonschema==2.6.0
-lxml==4.2.5               # via parsel, premailer, scrapy
-markupsafe==1.0           # via jinja2
+lxml==4.3.1               # via parsel, premailer, scrapy
+markupsafe==1.1.0         # via jinja2
 mock==1.0.1               # via schematics
-monkeylearn==3.2.1
-parsel==1.5.0             # via scrapy
-pillow==5.3.0
+monkeylearn==3.2.4
+parsel==1.5.1             # via scrapy
+pillow==5.4.1
 premailer==2.9.2
-pyasn1-modules==0.2.2     # via service-identity
-pyasn1==0.4.4             # via pyasn1-modules, rsa, service-identity
+pyasn1-modules==0.2.4     # via service-identity
+pyasn1==0.4.5             # via pyasn1-modules, rsa, service-identity
 pycparser==2.19           # via cffi
 pydispatcher==2.0.5       # via scrapy
 pyhamcrest==1.9.0         # via twisted
-pyopenssl==18.0.0         # via scrapy, service-identity
-python-dateutil==2.7.3    # via botocore
-python-slugify==1.2.6
+pyopenssl==19.0.0         # via scrapy
+python-dateutil==2.8.0    # via botocore
+python-slugify==2.0.1
 pyyaml==3.13              # via awscli
 queuelib==1.5.0           # via scrapy
-requests==2.19.1          # via monkeylearn, scrapinghub, slackclient
+requests==2.21.0          # via monkeylearn, scrapinghub, slackclient
 retrying==1.3.3           # via scrapinghub
 rsa==3.4.2                # via awscli
-s3transfer==0.1.13        # via awscli
+s3transfer==0.2.0         # via awscli
 schematics==1.0.4
 scrapinghub-entrypoint-scrapy==0.11.2
-scrapinghub==2.0.3
-scrapy-crawlera==1.4.0
+scrapinghub==2.1.0
+scrapy-crawlera==1.5.0
 scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.3.0
 scrapy-pagestorage==0.2.2
 scrapy-splash==0.7.2
-scrapy==1.5.2
+scrapy==1.6.0
 scrapylib==1.7.1
-service-identity==17.0.0  # via scrapy
-six==1.11.0
+service-identity==18.1.0  # via scrapy
+six==1.12.0
 slackclient==1.3.0
 twisted==18.9.0
-unidecode==1.0.22         # via python-slugify
-urllib3==1.23             # via botocore, requests
-w3lib==1.19.0             # via parsel, scrapy, scrapy-crawlera
-websocket-client==0.53.0  # via slackclient
-zope.interface==4.5.0     # via twisted
+unidecode==1.0.23         # via python-slugify
+urllib3==1.24.1           # via botocore, requests
+w3lib==1.20.0             # via parsel, scrapy, scrapy-crawlera
+websocket-client==0.54.0  # via slackclient
+zope.interface==4.6.0     # via twisted


### PR DESCRIPTION
Creating `scrapy:1.6-py3` stack based on the latest existing stack for Python 3 (`1.5-py3`).