### PR TITLE
Release stack with python:3.7 and latest scrapy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -qq && \
         libxml2-dev \
         libssl-dev \
         libxslt1-dev \
-        libmysqlclient-dev \
+        default-libmysqlclient-dev \
         libpq-dev \
         libevent-dev \
         libffi-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-jessie
+FROM python:3.7-stretch
 ARG PIP_INDEX_URL
 ARG PIP_TRUSTED_HOST
 ARG APT_PROXY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-jessie
+FROM python:3.7-jessie
 ARG PIP_INDEX_URL
 ARG PIP_TRUSTED_HOST
 ARG APT_PROXY


### PR DESCRIPTION
Python 3.7 is not fully backward compatible with Python 3.6 ([release notes](https://docs.python.org/3/whatsnew/3.7.html#porting-to-python-3-7)), it also requires `stretch` based image, so we're going to release a separate stack `1.6-py37`, at least for now.