### PR TITLE
Use latest dependencies for 1.6-py37

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,6 +22,7 @@ monkeylearn
 six
 Jinja2
 jsonschema
+msgpack
 premailer==2.9.2
 schematics==1.0.4
 scrapinghub==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,33 +5,34 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 asn1crypto==0.24.0        # via cryptography
-attrs==18.2.0             # via automat, service-identity, twisted
+attrs==19.1.0             # via automat, jsonschema, service-identity, twisted
 automat==0.7.0            # via twisted
-awscli==1.16.101          # via scrapy-dotpersistence
+awscli==1.16.144          # via scrapy-dotpersistence
 boto==2.49.0
-botocore==1.12.91         # via awscli, s3transfer
+botocore==1.12.134        # via awscli, s3transfer
 bsddb3==6.2.6             # via scrapy-deltafetch
-certifi==2018.11.29       # via requests
-cffi==1.11.5              # via cryptography
+certifi==2019.3.9         # via requests
+cffi==1.12.3              # via cryptography
 chardet==3.0.4            # via requests
 colorama==0.3.9           # via awscli
 constantly==15.1.0        # via twisted
-cryptography==2.5         # via pyopenssl, service-identity
+cryptography==2.6.1       # via pyopenssl, service-identity
 cssselect==1.0.3          # via parsel, premailer, scrapy
 cssutils==1.0.2           # via premailer
 docutils==0.14            # via awscli, botocore
-hyperlink==18.0.0         # via twisted
+hyperlink==19.0.0         # via twisted
 idna==2.8                 # via hyperlink, requests
 incremental==17.5.0       # via twisted
-jinja2==2.10
-jmespath==0.9.3           # via botocore
-jsonschema==2.6.0
-lxml==4.3.1               # via parsel, premailer, scrapy
-markupsafe==1.1.0         # via jinja2
+jinja2==2.10.1
+jmespath==0.9.4           # via botocore
+jsonschema==3.0.1
+lxml==4.3.3               # via parsel, premailer, scrapy
+markupsafe==1.1.1         # via jinja2
 mock==1.0.1               # via schematics
 monkeylearn==3.2.4
+msgpack==0.6.1
 parsel==1.5.1             # via scrapy
-pillow==5.4.1
+pillow==6.0.0
 premailer==2.9.2
 pyasn1-modules==0.2.4     # via service-identity
 pyasn1==0.4.5             # via pyasn1-modules, rsa, service-identity
@@ -39,8 +40,9 @@ pycparser==2.19           # via cffi
 pydispatcher==2.0.5       # via scrapy
 pyhamcrest==1.9.0         # via twisted
 pyopenssl==19.0.0         # via scrapy
+pyrsistent==0.14.11       # via jsonschema
 python-dateutil==2.8.0    # via botocore
-python-slugify==2.0.1
+python-slugify==3.0.2
 pyyaml==3.13              # via awscli
 queuelib==1.5.0           # via scrapy
 requests==2.21.0          # via monkeylearn, scrapinghub, slackclient
@@ -59,10 +61,10 @@ scrapy==1.6.0
 scrapylib==1.7.1
 service-identity==18.1.0  # via scrapy
 six==1.12.0
-slackclient==1.3.0
-twisted==18.9.0
-unidecode==1.0.23         # via python-slugify
-urllib3==1.24.1           # via botocore, requests
+slackclient==1.3.1
+text-unidecode==1.2       # via python-slugify
+twisted==19.2.0
+urllib3==1.24.2           # via botocore, requests
 w3lib==1.20.0             # via parsel, scrapy, scrapy-crawlera
 websocket-client==0.54.0  # via slackclient
 zope.interface==4.6.0     # via twisted


### PR DESCRIPTION
Let's also use all the recent dependencies in the brand new stack.