### PR TITLE
Add updated addons packages (1.6-py3)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,10 @@ scrapy-splash
 scrapy-crawlera
 scrapy-deltafetch
 scrapy-dotpersistence
-scrapy-pagestorage
+scrapy-magicfields
+scrapy-pagestorag
+scrapy-querycleaner
+scrapy-splitvariants
 
 # required by Monkeylearn addon
 monkeylearn

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ scrapy-crawlera
 scrapy-deltafetch
 scrapy-dotpersistence
 scrapy-magicfields
-scrapy-pagestorag
+scrapy-pagestorage
 scrapy-querycleaner
 scrapy-splitvariants
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,8 +53,11 @@ scrapinghub==2.1.1
 scrapy-crawlera==1.5.0
 scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.3.0
+scrapy-magicfields==1.1.0
 scrapy-pagestorage==0.2.2
+scrapy-querycleaner==1.0.0
 scrapy-splash==0.7.2
+scrapy-splitvariants==1.1.0
 scrapy==1.6.0
 scrapylib==1.7.1
 service-identity==18.1.0  # via scrapy


### PR DESCRIPTION
scrapylib doesn't support python-3, so the new versions of the addons should be installed explicitly.

