### PR TITLE
Add updated addons packages (1.7-py3)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,10 @@ scrapy-splash
 scrapy-crawlera
 scrapy-deltafetch
 scrapy-dotpersistence
+scrapy-magicfields
 scrapy-pagestorage
+scrapy-querycleaner
+scrapy-splitvariants
 
 # required by Monitoring addon
 spidermon[monitoring,validation]

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,8 +56,11 @@ scrapinghub==2.2.1
 scrapy-crawlera==1.6.0
 scrapy-deltafetch==1.2.1
 scrapy-dotpersistence==0.3.0
+scrapy-magicfields==1.1.0
 scrapy-pagestorage==0.3.0
+scrapy-querycleaner==1.0.0
 scrapy-splash==0.7.2
+scrapy-splitvariants==1.1.0
 scrapy==1.7.3
 scrapylib==1.7.1
 sentry-sdk==0.10.2        # via spidermon


### PR DESCRIPTION
scrapylib is deprecated, we should migrate towards the new packages for the addons, and drop scrapylib from the next 1.8 stacks.