### PR TITLE
Improve and clean Dockerfile logic (1.7-py38)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ONBUILD ARG PIP_INDEX_URL
 ONBUILD ARG PIP_TRUSTED_HOST
 ONBUILD ARG APT_PROXY
 ONBUILD ENV PIP_TRUSTED_HOST=$PIP_TRUSTED_HOST PIP_INDEX_URL=$PIP_INDEX_URL
-ONBUILD RUN test -n "$APT_PROXY" && echo "Acquire::http::Proxy \"$APT_PROXY\";" \
-    >/etc/apt/apt.conf.d/proxy
+ONBUILD RUN if [ -n "$APT_PROXY" ]; then \
+    echo "Acquire::http::Proxy \"$APT_PROXY\";" >/etc/apt/apt.conf.d/proxy; fi
 
 # TERM needs to be set here for exec environments
 # PIP_TIMEOUT so installation doesn't hang forever

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.8-slim-buster
-ARG PIP_INDEX_URL
-ARG PIP_TRUSTED_HOST
-ARG APT_PROXY
+# the args must be onbuild to allow overwriting it in derived images
+# https://github.com/moby/moby/issues/26533#issuecomment-246966836
+ONBUILD ARG PIP_INDEX_URL
+ONBUILD ARG PIP_TRUSTED_HOST
+ONBUILD ARG APT_PROXY
 ONBUILD ENV PIP_TRUSTED_HOST=$PIP_TRUSTED_HOST PIP_INDEX_URL=$PIP_INDEX_URL
-ONBUILD RUN test -n $APT_PROXY && echo 'Acquire::http::Proxy \"$APT_PROXY\";' \
+ONBUILD RUN test -n "$APT_PROXY" && echo "Acquire::http::Proxy \"$APT_PROXY\";" \
     >/etc/apt/apt.conf.d/proxy
 
 # TERM needs to be set here for exec environments
@@ -34,9 +36,8 @@ RUN apt-get update -qq && \
         libz-dev \
         unixodbc unixodbc-dev \
         telnet vim htop iputils-ping curl wget lsof git sudo \
-        ghostscript
-# http://unix.stackexchange.com/questions/195975/cannot-force-remove-directory-in-docker-build
-#        && rm -rf /var/lib/apt/lists
+        ghostscript && \
+    rm -rf /var/lib/apt/lists
 
 # adding custom locales to provide backward support with scrapy cloud 1.0
 COPY locales /etc/locale.gen


### PR DESCRIPTION
There's a few issues at the same time:
- the bug with AUFS was fixed a long time ago, we can drop the packages lists to win some space
- the args used in onbuild ops must be defined as onbuild too, see the link for details
- there was a tiny quoting bug in testing for `APT_PROXY`, so it didn't work properly in all cases
- for some reason `test` expression fails when used in onbuild, but simple if condition works fine