### PR TITLE
Add boto3, upgrade dependencies [1.8-py3]

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,12 +24,13 @@ scrapy-splitvariants
 
 # required by Monitoring addon
 spidermon[monitoring,validation]
-
 # required by Monkeylearn addon
 monkeylearn
 # required by Images addon
 boto
 pillow>=5.1.0
+# pre-install boto3 compatible with botocore
+boto3
 
 # Requirements due to known bugs in dependencies
 Twisted >= 17.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,13 @@
 #
 attrs==19.3.0             # via automat, jsonschema, service-identity, twisted
 automat==0.8.0            # via twisted
-awscli==1.16.277
+awscli==1.16.292
+boto3==1.10.28
 boto==2.49.0
-botocore==1.13.13         # via awscli, s3transfer
+botocore==1.13.28         # via awscli, boto3, s3transfer
 bsddb3==6.2.6             # via scrapy-deltafetch
 cachetools==3.1.1         # via premailer
-certifi==2019.9.11        # via requests, sentry-sdk
+certifi==2019.11.28       # via requests, sentry-sdk
 cffi==1.13.2              # via cryptography
 chardet==3.0.4            # via requests
 colorama==0.4.1           # via awscli
@@ -22,27 +23,27 @@ cssutils==1.0.2           # via premailer
 docutils==0.15.2          # via awscli, botocore
 hyperlink==19.0.0         # via twisted
 idna==2.8                 # via hyperlink, jsonschema, requests
-importlib-metadata==0.23  # via jsonschema
+importlib-metadata==1.1.0  # via jsonschema
 incremental==17.5.0       # via twisted
 jinja2==2.10.3
-jmespath==0.9.4           # via botocore
+jmespath==0.9.4           # via boto3, botocore
 jsonpointer==2.0          # via jsonschema
-jsonschema[format]==3.1.1  # via spidermon
-lxml==4.4.1               # via parsel, premailer, scrapy
+jsonschema[format]==3.2.0  # via spidermon
+lxml==4.4.2               # via parsel, premailer, scrapy
 markupsafe==1.1.1         # via jinja2
 monkeylearn==3.5.1
-more-itertools==7.2.0     # via zipp
+more-itertools==8.0.0     # via zipp
 parsel==1.5.2             # via scrapy
 pillow==6.2.1
 premailer==3.6.1          # via spidermon
 protego==0.1.15           # via scrapy
 pyasn1-modules==0.2.7     # via service-identity
-pyasn1==0.4.7             # via pyasn1-modules, rsa, service-identity
+pyasn1==0.4.8             # via pyasn1-modules, rsa, service-identity
 pycparser==2.19           # via cffi
 pydispatcher==2.0.5       # via scrapy
 pyhamcrest==1.9.0         # via twisted
-pyopenssl==19.0.0         # via scrapy
-pyrsistent==0.15.5        # via jsonschema
+pyopenssl==19.1.0         # via scrapy
+pyrsistent==0.15.6        # via jsonschema
 python-dateutil==2.8.0    # via botocore
 python-slugify==4.0.0     # via spidermon
 pyyaml==5.1.2
@@ -51,7 +52,7 @@ requests==2.22.0
 retrying==1.3.3           # via scrapinghub
 rfc3987==1.3.8            # via jsonschema
 rsa==3.4.2                # via awscli
-s3transfer==0.2.1         # via awscli
+s3transfer==0.2.1         # via awscli, boto3
 schematics==2.1.0         # via spidermon
 scrapinghub-entrypoint-scrapy==0.12.0
 scrapinghub==2.2.1
@@ -65,17 +66,17 @@ scrapy-splash==0.7.2
 scrapy-splitvariants==1.1.0
 scrapy==1.8.0
 scrapylib==1.7.1
-sentry-sdk==0.13.2        # via spidermon
+sentry-sdk==0.13.4        # via spidermon
 service-identity==18.1.0  # via scrapy
 six==1.13.0               # via automat, cryptography, jsonschema, monkeylearn, parsel, protego, pyhamcrest, pyopenssl, pyrsistent, python-dateutil, retrying, scrapinghub, scrapy, scrapy-crawlera, scrapy-querycleaner, slackclient, spidermon, w3lib, webcolors, websocket-client
 slackclient==1.3.2        # via spidermon
 spidermon[monitoring,validation]==1.11.0
 strict-rfc3339==0.7       # via jsonschema
 text-unidecode==1.3       # via python-slugify
-twisted==19.7.0
-urllib3==1.25.6
+twisted==19.10.0
+urllib3==1.25.7
 w3lib==1.21.0             # via parsel, scrapy, scrapy-crawlera
 webcolors==1.10           # via jsonschema
 websocket-client==0.54.0  # via slackclient
 zipp==0.6.0               # via importlib-metadata
-zope.interface==4.6.0     # via scrapy, twisted
+zope.interface==4.7.1     # via scrapy, twisted


### PR DESCRIPTION
As `boto` is no longer maintained and replaced by `boto3`, we should start adding the lib into the latest stacks. Another reason to do it is as the stack doesn't provide `boto3`, when user adds it via requirements.txt, a correct version must be specified to be compatible with already installed `botocore` library, otherwise the build will fail. It's a bad practice to require user constantly watching for the dependency version updated by us from time to time. In the PR I suggest to add `boto3` explicitly and update all requirements (haven't noticed any dangerous updates, but please take a look).