### PR TITLE
Update Dockerfile to python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.10-slim-buster
 # the args must be onbuild to allow overwriting it in derived images
 # https://github.com/moby/moby/issues/26533#issuecomment-246966836
 ONBUILD ARG PIP_INDEX_URL


### PR DESCRIPTION
Python 3.10.2 is stable, and the current version.

* [Docker Hub entry](https://hub.docker.com/layers/python/library/python/3.10-slim-buster/images/sha256-c56315b7cce6b565682abb6eb2e4d456d002c2f802d1ad2bf08ddf6a58581d15?context=explore)

Resolves #164 