### PR TITLE
Update PyYAML to 6.0.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,7 @@ scrapy-querycleaner
 scrapy-splitvariants
 
 # required by Monitoring addon
-spidermon[monitoring,validation]
+spidermon[monitoring]
 # required by Monkeylearn addon
 monkeylearn
 # required by Images addon

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,11 +17,12 @@ attrs==23.1.0
     #   aiohttp
     #   automat
     #   jsonschema
+    #   referencing
     #   service-identity
     #   twisted
 automat==22.10.0
     # via twisted
-awscli==1.27.129
+awscli==1.29.5
     # via
     #   -r requirements.in
     #   scrapy-dotpersistence
@@ -29,16 +30,16 @@ boto==2.49.0
     # via
     #   -r requirements.in
     #   spidermon
-boto3==1.26.129
+boto3==1.28.5
     # via
     #   -r requirements.in
     #   spidermon
-botocore==1.29.129
+botocore==1.31.5
     # via
     #   awscli
     #   boto3
     #   s3transfer
-cachetools==5.3.0
+cachetools==5.3.1
     # via premailer
 certifi==2023.5.7
     # via
@@ -46,7 +47,7 @@ certifi==2023.5.7
     #   sentry-sdk
 cffi==1.15.1
     # via cryptography
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via
     #   aiohttp
     #   requests
@@ -54,7 +55,7 @@ colorama==0.4.4
     # via awscli
 constantly==15.1.0
     # via twisted
-cryptography==40.0.2
+cryptography==41.0.2
     # via
     #   -r requirements.in
     #   pyopenssl
@@ -65,15 +66,15 @@ cssselect==1.2.0
     #   parsel
     #   premailer
     #   scrapy
-cssutils==2.6.0
+cssutils==2.7.1
     # via premailer
 docutils==0.16
     # via awscli
-filelock==3.12.0
+filelock==3.12.2
     # via tldextract
 fqdn==1.5.1
     # via jsonschema
-frozenlist==1.3.3
+frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
@@ -112,17 +113,19 @@ jmespath==1.0.1
     #   botocore
     #   itemloaders
     #   parsel
-jsonpointer==2.3
+jsonpointer==2.4
     # via jsonschema
-jsonschema[format]==4.17.3
+jsonschema[format]==4.18.4
     # via spidermon
-lxml==4.9.2
+jsonschema-specifications==2023.7.1
+    # via jsonschema
+lxml==4.9.3
     # via
     #   -r requirements.in
     #   parsel
     #   premailer
     #   scrapy
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 monkeylearn==3.6.0
     # via -r requirements.in
@@ -138,7 +141,7 @@ parsel==1.8.1
     # via
     #   itemloaders
     #   scrapy
-pillow==9.5.0
+pillow==10.0.0
     # via -r requirements.in
 premailer==3.10.0
     # via spidermon
@@ -157,23 +160,25 @@ pycparser==2.21
     # via cffi
 pydispatcher==2.0.7
     # via scrapy
-pyopenssl==23.1.1
+pyopenssl==23.2.0
     # via scrapy
-pyrsistent==0.19.3
-    # via jsonschema
 python-dateutil==2.8.2
     # via
     #   arrow
     #   botocore
 python-slugify==8.0.1
     # via spidermon
-pyyaml==5.4.1
+pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   awscli
 queuelib==1.6.2
     # via scrapy
-requests==2.30.0
+referencing==0.30.0
+    # via
+    #   jsonschema
+    #   jsonschema-specifications
+requests==2.31.0
     # via
     #   -r requirements.in
     #   monkeylearn
@@ -189,14 +194,16 @@ rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8
     # via jsonschema
+rpds-py==0.9.2
+    # via
+    #   jsonschema
+    #   referencing
 rsa==4.7.2
     # via awscli
 s3transfer==0.6.1
     # via
     #   awscli
     #   boto3
-schematics==2.1.1
-    # via spidermon
 scrapinghub==2.4.0
     # via
     #   -r requirements.in
@@ -238,9 +245,9 @@ scrapy-splitvariants==1.1.0
     # via -r requirements.in
 scrapy-zyte-smartproxy==2.2.0
     # via -r requirements.in
-sentry-sdk==1.22.2
+sentry-sdk==1.28.1
     # via spidermon
-service-identity==21.1.0
+service-identity==23.1.0
     # via scrapy
 six==1.16.0
     # via
@@ -255,24 +262,23 @@ six==1.16.0
     #   scrapy-crawlera
     #   scrapy-querycleaner
     #   scrapy-zyte-smartproxy
-    #   service-identity
 slack-sdk==3.21.3
     # via spidermon
-spidermon[monitoring,validation]==1.18.0
+spidermon[monitoring]==1.19.0
     # via -r requirements.in
 text-unidecode==1.3
     # via python-slugify
-tldextract==3.4.1
+tldextract==3.4.4
     # via scrapy
 twisted[http2]==22.10.0
     # via
     #   -r requirements.in
     #   scrapy
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via twisted
-uri-template==1.2.0
+uri-template==1.3.0
     # via jsonschema
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -r requirements.in
     #   botocore


### PR DESCRIPTION
Due to https://github.com/yaml/pyyaml/issues/724 we need to upgrade [pyyaml==5.4.1](https://github.com/scrapinghub/scrapinghub-stack-scrapy/blob/2.9-20230519/requirements.txt#L170) to `6.0.1`.