### PR TITLE
Bump scrapinghub-entrypoint-scrapy and other dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@
 Scrapy==2.11.2
 
 # scrapinghub glue
-scrapinghub-entrypoint-scrapy>=0.17.2
+scrapinghub-entrypoint-scrapy==0.17.4
 
 # official python client
 scrapinghub>=2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,23 +4,24 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-aiohttp==3.9.5
+aiohappyeyeballs==2.4.0
+    # via aiohttp
+aiohttp==3.10.5
     # via -r requirements.in
 aiosignal==1.3.1
     # via aiohttp
 arrow==1.3.0
     # via isoduration
-attrs==23.2.0
+attrs==24.2.0
     # via
     #   aiohttp
-    #   automat
     #   jsonschema
     #   referencing
     #   service-identity
     #   twisted
-automat==22.10.0
+automat==24.8.1
     # via twisted
-awscli==1.32.104
+awscli==1.34.20
     # via
     #   -r requirements.in
     #   scrapy-dotpersistence
@@ -28,22 +29,22 @@ boto==2.49.0
     # via
     #   -r requirements.in
     #   spidermon
-boto3==1.34.104
+boto3==1.35.20
     # via
     #   -r requirements.in
     #   spidermon
-botocore==1.34.104
+botocore==1.35.20
     # via
     #   awscli
     #   boto3
     #   s3transfer
-cachetools==5.3.3
+cachetools==5.5.0
     # via premailer
-certifi==2024.2.2
+certifi==2024.8.30
     # via
     #   requests
     #   sentry-sdk
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
@@ -51,7 +52,7 @@ colorama==0.4.6
     # via awscli
 constantly==23.10.4
     # via twisted
-cryptography==42.0.7
+cryptography==43.0.1
     # via
     #   pyopenssl
     #   scrapy
@@ -61,13 +62,13 @@ cssselect==1.2.0
     #   parsel
     #   premailer
     #   scrapy
-cssutils==2.10.3
+cssutils==2.11.1
     # via premailer
 defusedxml==0.7.1
     # via scrapy
 docutils==0.16
     # via awscli
-filelock==3.14.0
+filelock==3.16.0
     # via tldextract
 fqdn==1.5.1
     # via jsonschema
@@ -83,14 +84,14 @@ hyperframe==6.0.1
     # via h2
 hyperlink==21.0.0
     # via twisted
-idna==3.7
+idna==3.10
     # via
     #   hyperlink
     #   jsonschema
     #   requests
     #   tldextract
     #   yarl
-incremental==22.10.0
+incremental==24.7.2
     # via twisted
 isoduration==20.11.0
     # via jsonschema
@@ -99,7 +100,7 @@ itemadapter==0.9.0
     #   itemloaders
     #   scrapy
     #   spidermon
-itemloaders==1.2.0
+itemloaders==1.3.1
     # via scrapy
 jinja2==3.1.4
     # via
@@ -111,13 +112,13 @@ jmespath==1.0.1
     #   botocore
     #   itemloaders
     #   parsel
-jsonpointer==2.4
+jsonpointer==3.0.0
     # via jsonschema
-jsonschema[format]==4.22.0
+jsonschema[format]==4.23.0
     # via spidermon
 jsonschema-specifications==2023.12.1
     # via jsonschema
-lxml==5.2.2
+lxml==5.3.0
     # via
     #   -r requirements.in
     #   parsel
@@ -127,11 +128,13 @@ markupsafe==2.1.5
     # via jinja2
 monkeylearn==3.6.0
     # via -r requirements.in
-multidict==6.0.5
+more-itertools==10.5.0
+    # via cssutils
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-packaging==24.0
+packaging==24.1
     # via
     #   parsel
     #   scrapy
@@ -139,7 +142,7 @@ parsel==1.9.1
     # via
     #   itemloaders
     #   scrapy
-pillow==10.3.0
+pillow==10.4.0
     # via -r requirements.in
 premailer==3.10.0
     # via spidermon
@@ -147,18 +150,18 @@ priority==1.3.0
     # via twisted
 protego==0.3.1
     # via scrapy
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   rsa
     #   service-identity
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.1
     # via service-identity
 pycparser==2.22
     # via cffi
 pydispatcher==2.0.7
     # via scrapy
-pyopenssl==24.1.0
+pyopenssl==24.2.1
     # via scrapy
 python-dateutil==2.9.0.post0
     # via
@@ -166,7 +169,7 @@ python-dateutil==2.9.0.post0
     #   botocore
 python-slugify==8.0.4
     # via spidermon
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements.in
     #   awscli
@@ -176,7 +179,7 @@ referencing==0.35.1
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.31.0
+requests==2.32.3
     # via
     #   -r requirements.in
     #   monkeylearn
@@ -185,7 +188,7 @@ requests==2.31.0
     #   scrapinghub
     #   spidermon
     #   tldextract
-requests-file==2.0.0
+requests-file==2.1.0
     # via tldextract
 retrying==1.3.4
     # via scrapinghub
@@ -193,13 +196,13 @@ rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8
     # via jsonschema
-rpds-py==0.18.1
+rpds-py==0.20.0
     # via
     #   jsonschema
     #   referencing
 rsa==4.7.2
     # via awscli
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   awscli
     #   boto3
@@ -209,7 +212,7 @@ scrapinghub==2.4.0
     #   scrapinghub-entrypoint-scrapy
     #   scrapy-pagestorage
     #   spidermon
-scrapinghub-entrypoint-scrapy==0.17.2
+scrapinghub-entrypoint-scrapy==0.17.4
     # via
     #   -r requirements.in
     #   scrapy-pagestorage
@@ -243,15 +246,14 @@ scrapy-splash==0.9.0
     # via -r requirements.in
 scrapy-splitvariants==1.1.0
     # via -r requirements.in
-scrapy-zyte-smartproxy==2.3.4
+scrapy-zyte-smartproxy==2.3.5
     # via -r requirements.in
-sentry-sdk==2.1.1
+sentry-sdk==2.14.0
     # via spidermon
 service-identity==24.1.0
     # via scrapy
 six==1.16.0
     # via
-    #   automat
     #   monkeylearn
     #   python-dateutil
     #   retrying
@@ -260,7 +262,7 @@ six==1.16.0
     #   scrapy-crawlera
     #   scrapy-querycleaner
     #   scrapy-zyte-smartproxy
-slack-sdk==3.27.1
+slack-sdk==3.33.0
     # via spidermon
 spidermon[monitoring]==1.22.0
     # via -r requirements.in
@@ -268,34 +270,34 @@ text-unidecode==1.3
     # via python-slugify
 tldextract==5.1.2
     # via scrapy
-twisted[http2]==24.3.0
+twisted[http2]==24.7.0
     # via
     #   -r requirements.in
     #   scrapy
-types-python-dateutil==2.9.0.20240316
+types-python-dateutil==2.9.0.20240906
     # via arrow
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via twisted
 uri-template==1.3.0
     # via jsonschema
-urllib3==2.2.1
+urllib3==2.2.3
     # via
     #   -r requirements.in
     #   botocore
     #   requests
     #   sentry-sdk
-w3lib==2.1.2
+w3lib==2.2.1
     # via
     #   itemloaders
     #   parsel
     #   scrapy
     #   scrapy-crawlera
     #   scrapy-zyte-smartproxy
-webcolors==1.13
+webcolors==24.8.0
     # via jsonschema
-yarl==1.9.4
+yarl==1.11.1
     # via aiohttp
-zope-interface==6.3
+zope-interface==7.0.3
     # via
     #   scrapy
     #   twisted


### PR DESCRIPTION
Main update is https://github.com/scrapinghub/scrapinghub-entrypoint-scrapy/releases/tag/v0.17.4