### PR TITLE
Update Debian base image and Python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.12.7-slim-bookworm
 # the args must be onbuild to allow overwriting it in derived images
 # https://github.com/moby/moby/issues/26533#issuecomment-246966836
 ONBUILD ARG PIP_INDEX_URL


### PR DESCRIPTION
* Debian Buster (10) to Bookworm (12)
* Python 3.11 to 3.12.7