### PR TITLE
Bump Python to 3.14.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.4-slim-bookworm
+FROM python:3.14.5-slim-bookworm
 # the args must be onbuild to allow overwriting it in derived images
 # https://github.com/moby/moby/issues/26533#issuecomment-246966836
 ONBUILD ARG PIP_INDEX_URL


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3145/